### PR TITLE
Changed setup-replication to use bash shell

### DIFF
--- a/setup-replication.sh
+++ b/setup-replication.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 if [ "x$REPLICATE_FROM" == "x" ]; then
 


### PR DESCRIPTION
The sh interpreter in the docker image was throwing:

> ./setup-replication.sh: 3: [: x: unexpected operator