### PR TITLE
replace `$PGUSER` and `$PGPASSWORD` with standard vars

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,8 @@ services:
     image: 'danieldent/postgres-replication'
     restart: 'always'
     environment:
-      PGUSER: 'postgres'
-      PGPASSWORD: 'postgres'
+      POSTGRES_USER: 'postgres'
+      POSTGRES_PASSWORD: 'postgres'
       PGDATA: '/var/lib/postgresql/data/pgdata'
     volumes:
      - '/var/lib/postgresql/data'
@@ -20,8 +20,8 @@ services:
     image: 'danieldent/postgres-replication'
     restart: 'always'
     environment:
-      PGUSER: 'postgres'
-      PGPASSWORD: 'postgres'
+      POSTGRES_USER: 'postgres'
+      POSTGRES_PASSWORD: 'postgres'
       PGDATA: '/var/lib/postgresql/data/pgdata'
       REPLICATE_FROM: 'pg-master'
     volumes:

--- a/setup-replication.sh
+++ b/setup-replication.sh
@@ -13,7 +13,7 @@ else
 
 cat > ${PGDATA}/recovery.conf <<EOF
 standby_mode = on
-primary_conninfo = 'host=${REPLICATE_FROM} port=5432 user=${PGUSER} password=${PGPASSWORD}'
+primary_conninfo = 'host=${REPLICATE_FROM} port=5432 user=${POSTGRES_USER} password=${POSTGRES_PASSWORD}'
 trigger_file = '/tmp/touch_me_to_promote_to_me_master'
 EOF
 chown postgres ${PGDATA}/recovery.conf


### PR DESCRIPTION
The [upstream image](https://hub.docker.com/_/postgres/) uses
`$POSTGRES_USER` and `$POSTGRES_PASSWORD` for configuration; since the
scripts in this image use `$PGUSER` and `$PGPASSWORD`, it's laborious to
port other init scripts that were written for the upstream image over to
this image.  I've changed this image's scripts to bring them in line
with upstream, to make it easier to drop this image into place as a
replacement.