### PR TITLE
Fix pg_basebackup not receiving password prompt properly.

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -50,7 +50,7 @@ if [ "$1" = 'postgres' ]; then
 
 		# check password first so we can output the warning before postgres
 		# messes it up
-		if [ ! -z "$POSTGRES_PASSWORD" ]; then
+		if [ "$POSTGRES_PASSWORD" ]; then
 			pass="PASSWORD '$POSTGRES_PASSWORD'"
 			authMethod=md5
 		else


### PR DESCRIPTION
With the current master the slave will spam "Password: " to the logs. This seems to be the result of `pg_basebackup` still using the `PG_PASSWORD` environment variable.

This patch populates that vaiable if it is not initially set, and allows everything to work. It also changes `pg_basebackup` to be called with the `-w` flag so it correctly fails if no password is found (which avoids the spam).